### PR TITLE
fix: incorrect ambiguous pawn capture pgn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "5d-chess-js",
-  "version": "1.1.4",
+  "name": "@nkid00/5d-chess-js",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.4",
+      "name": "@nkid00/5d-chess-js",
+      "version": "1.2.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "blueimp-md5": "^2.18.0",
@@ -737,7 +738,6 @@
         "jest-resolve": "^26.4.0",
         "jest-util": "^26.3.0",
         "jest-worker": "^26.3.0",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2619,7 +2619,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2718,7 +2717,6 @@
       "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "dependencies": {
-        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
       },
@@ -6909,7 +6907,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.3.0",
@@ -7970,7 +7967,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,14 @@
 {
-  "name": "5d-chess-js",
+  "name": "@nkid00/5d-chess-js",
+  "repository": "https://github.com/NKID00/5d-chess-js",
+  "bugs": {
+    "url": "https://github.com/NKID00/5d-chess-js/issues"
+  },
+  "homepage": "https://github.com/NKID00/5d-chess-js",
+  "description": "A fork of 5d-chess-js with bugfixes.",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "author": {
     "name": "Shaun Wu",
     "email": "alexbay218@gmail.com"
@@ -16,10 +25,13 @@
     {
       "name": "Neathp",
       "url": "https://gitlab.com/ehphillips.neathp"
+    },
+    {
+      "name": "NKID00",
+      "url": "https://github.com/NKID00"
     }
   ],
-  "version": "1.2.1",
-  "description": "Open source implementation of '5D Chess With Multiverse Time Travel' in the style of Chess.js library with built-in notation support.",
+  "version": "1.2.2",
   "main": "./dist/5d-chess.js",
   "browser": {
     "module-alias/register": false
@@ -51,14 +63,7 @@
       "^@local(.*)$": "<rootDir>/src/$1"
     }
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://gitlab.com/5d-chess/5d-chess-js.git"
-  },
   "license": "AGPL-3.0-or-later",
-  "bugs": {
-    "url": "https://gitlab.com/5d-chess/5d-chess-js/issues"
-  },
   "keywords": [
     "chess",
     "5d",
@@ -69,7 +74,6 @@
     "node",
     "browser"
   ],
-  "homepage": "https://gitlab.com/5d-chess/5d-chess-js#readme",
   "dependencies": {
     "blueimp-md5": "^2.18.0",
     "module-alias": "^2.2.2",

--- a/src/pgn.js
+++ b/src/pgn.js
@@ -223,7 +223,6 @@ exports.fromMove = (move, fullBoard = [], actionNum = 0, suffix = '', timelineAc
     } else {
 
       res += pieceChar;
-      console.log("HELLO!!");
       res += this.ambiguousSan(move, fullBoard, actionNum, [], null);
     }
   }

--- a/src/pgn.js
+++ b/src/pgn.js
@@ -77,7 +77,7 @@ exports.ambiguousSan = (move, fullBoard, actionNum = 0, moveGen = [], promotionP
   }
 
   if (Math.abs(destPiece) != 0 || move.length == 3) {
-    if (Math.abs(piece) == 1 || Math.abs(piece) == 2 && !conflict) {
+    if ((Math.abs(piece) == 1 || Math.abs(piece) == 2) && !conflict) {
 
       res += this.toSanCoord([src[2], src[3]])[0];
 
@@ -223,6 +223,7 @@ exports.fromMove = (move, fullBoard = [], actionNum = 0, suffix = '', timelineAc
     } else {
 
       res += pieceChar;
+      console.log("HELLO!!");
       res += this.ambiguousSan(move, fullBoard, actionNum, [], null);
     }
   }

--- a/src/pgn.js
+++ b/src/pgn.js
@@ -223,9 +223,7 @@ exports.fromMove = (move, fullBoard = [], actionNum = 0, suffix = '', timelineAc
     } else {
 
       res += pieceChar;
-      if(Math.abs(srcPiece)>2){
-        res += this.ambiguousSan(move, fullBoard, actionNum, [], null);
-      }
+      res += this.ambiguousSan(move, fullBoard, actionNum, [], null);
     }
   }
 


### PR DESCRIPTION
When black has two pawns available to capture the same piece, notation of the capture results in duplicate file (column of the board) indicator.